### PR TITLE
feat: make sshd args configurable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,8 @@ RUN mv /home /data && ln -s /data/home /home
 
 COPY bin /usr/bin
 
-ENV SSH_USER=user
+ENV SSH_USER=user \
+    DEFAULT_SSHD_ARGS="-D -f /data/etc/ssh/sshd_config"
 EXPOSE 22
 VOLUME [ "/data" ]
 

--- a/README.md
+++ b/README.md
@@ -31,6 +31,22 @@ e6f93a820b48:~$
 | Name | Default | Description |
 | ---- | ------- | ----------- |
 | SSH_USER | user | Username to be created.<br>It is added to `wheel` group and can sudo without password.<br>Random password assign and printed to logs, if the user did not already exist |
+| DEFAULT_SSHD_ARGS | `-D -f /data/etc/ssh/sshd_config` | Default arguments passed to `sshd.pam` before any container command arguments are appended |
+
+You can append extra `sshd` args via the container command, for example:
+
+```sh
+docker run ... ghcr.io/fopina/ssh-bastion:latest -e
+```
+
+To fully replace the defaults, clear `DEFAULT_SSHD_ARGS` and provide your own command args:
+
+```sh
+docker run ... \
+  -e DEFAULT_SSHD_ARGS='' \
+  ghcr.io/fopina/ssh-bastion:latest \
+  -D -e -f /data/etc/ssh/sshd_config
+```
 
 ### Volumes
 

--- a/bin/entrypoint.sh
+++ b/bin/entrypoint.sh
@@ -18,4 +18,7 @@ fi
 
 /data/custom-entrypoint.sh
 
-exec /sbin/tini -- /usr/sbin/sshd.pam -D -f /data/etc/ssh/sshd_config
+: "${DEFAULT_SSHD_ARGS:=-D -f /data/etc/ssh/sshd_config}"
+
+# shellcheck disable=SC2086
+exec /sbin/tini -- /usr/sbin/sshd.pam ${DEFAULT_SSHD_ARGS} "$@"

--- a/bin/entrypoint.sh
+++ b/bin/entrypoint.sh
@@ -18,7 +18,5 @@ fi
 
 /data/custom-entrypoint.sh
 
-: "${DEFAULT_SSHD_ARGS:=-D -f /data/etc/ssh/sshd_config}"
-
 # shellcheck disable=SC2086
 exec /sbin/tini -- /usr/sbin/sshd.pam ${DEFAULT_SSHD_ARGS} "$@"


### PR DESCRIPTION
## Summary
- add `DEFAULT_SSHD_ARGS` for built-in sshd defaults
- pass container command/CMD args through to `sshd.pam`
- document how to append or fully replace sshd args

## Verification
- `sh -n bin/entrypoint.sh`