### PR TITLE
feat: add sshd logging to default args

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,7 @@ RUN mv /home /data && ln -s /data/home /home
 COPY bin /usr/bin
 
 ENV SSH_USER=user \
-    DEFAULT_SSHD_ARGS="-D -f /data/etc/ssh/sshd_config"
+    DEFAULT_SSHD_ARGS="-D -e -f /data/etc/ssh/sshd_config"
 EXPOSE 22
 VOLUME [ "/data" ]
 

--- a/README.md
+++ b/README.md
@@ -31,12 +31,12 @@ e6f93a820b48:~$
 | Name | Default | Description |
 | ---- | ------- | ----------- |
 | SSH_USER | user | Username to be created.<br>It is added to `wheel` group and can sudo without password.<br>Random password assign and printed to logs, if the user did not already exist |
-| DEFAULT_SSHD_ARGS | `-D -f /data/etc/ssh/sshd_config` | Default arguments passed to `sshd.pam` before any container command arguments are appended |
+| DEFAULT_SSHD_ARGS | `-D -e -f /data/etc/ssh/sshd_config` | Default arguments passed to `sshd.pam` before any container command arguments are appended |
 
 You can append extra `sshd` args via the container command, for example:
 
 ```sh
-docker run ... ghcr.io/fopina/ssh-bastion:latest -e
+docker run ... ghcr.io/fopina/ssh-bastion:latest -o LogLevel=VERBOSE
 ```
 
 To fully replace the defaults, clear `DEFAULT_SSHD_ARGS` and provide your own command args:


### PR DESCRIPTION
## Summary
- add `-e` to the default sshd args so logs go to stderr
- update README examples/documentation for the new default

## Verification
- inspected the resulting diff